### PR TITLE
fix(security): fix cookies leakage between different users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Removed` for now removed features.
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
+- `[YANKED]` for deprecated releases.
 
 <!-- Refer to: https://github.com/olivierlacan/keep-a-changelog/blob/main/CHANGELOG.md -->
 <!-- Refer to: https://github.com/gradio-app/gradio/blob/main/CHANGELOG.md -->
 
 ## [Unreleased]
 
-None.
+### Security
+
+- [#10](https://github.com/WSH032/fastapi-proxy-lib/pull/10) - fix security vulnerabilities of cookies leakage between different users. Thanks [@WSH032](https://github.com/WSH032)!
 
 ## [0.0.1b0] - 2023-11-27 [YANKED]
 

--- a/docs/Usage/Security.md
+++ b/docs/Usage/Security.md
@@ -51,3 +51,25 @@ For this situation, the browser's same-origin protection policy will fail,
 and cookies from `http://www.example.com/` will be sent to` http://www.google.com/`.
 
 You should inform the user of this situation and let them decide whether to continue.
+
+---
+
+## What did `fastapi-proxy-lib` do to protect your Security? 🔐
+
+!!! info
+    The following content is the security measures taken by `fastapi-proxy-lib` behind the scenes.
+    You may not need to read these for using this library.
+
+### Forbid the merging of cookies at the AsyncClient level
+
+For fix security vulnerabilities of cookies leakage between different users:
+
+- Before sending each proxy request, `fastapi-proxy-lib` will clear `AsyncClient.cookies` to avoid recording cookies from different users.
+- To prevent `AsyncClient` merge cookie, `fastapi-proxy-lib` will forcibly add an empty cookie string `""` to each proxy request that does not contain a cookie field header.
+
+Through these, `fastapi-proxy-lib` hopes to prevent the mergence and sharing of cookies from different users.
+
+More info, please visit [Security Advisories `GHSA-7vwr-g6pm-9hc8`](https://github.com/WSH032/fastapi-proxy-lib/security/advisories/GHSA-7vwr-g6pm-9hc8) and [#10](https://github.com/WSH032/fastapi-proxy-lib/pull/10).
+
+!!! note
+    It will **not affect** the normal sending and receiving of cookies.

--- a/tests/app/echo_http_app.py
+++ b/tests/app/echo_http_app.py
@@ -12,7 +12,7 @@ from .tool import AppDataclass4Test, RequestDict
 DEFAULT_FILE_NAME = "echo.txt"
 
 
-def get_app() -> AppDataclass4Test:
+def get_app() -> AppDataclass4Test:  # noqa: C901
     """Get the echo http app.
 
     Returns:
@@ -82,6 +82,28 @@ def get_app() -> AppDataclass4Test:
             "query_params": request.query_params,
         }
         return msg
+
+    @app.get("/get/cookies")
+    async def cookies(
+        request: Request,
+    ) -> Mapping[str, str]:
+        """Returns cookie of request."""
+        nonlocal test_app_dataclass
+        test_app_dataclass.request_dict["request"] = request
+        return request.cookies
+
+    @app.get("/get/cookies/set/{key}/{value}")
+    async def cookies_set(
+        request: Request,
+        key: str,
+        value: str,
+    ) -> Response:
+        """Returns a response which requires client to set cookie: `key=value`."""
+        nonlocal test_app_dataclass
+        test_app_dataclass.request_dict["request"] = request
+        response = Response()
+        response.set_cookie(key=key, value=value)
+        return response
 
     @app.post("/post/echo_body")
     async def echo_body(request: Request) -> Response:


### PR DESCRIPTION
# Summary

- fix security vulnerabilities of cookies leakage between different users

Security-advisories: [GHSA-7vwr-g6pm-9hc8](https://github.com/WSH032/fastapi-proxy-lib/security/advisories/GHSA-7vwr-g6pm-9hc8)

# Checklist

- [x] I've read `CONTRIBUTING.md`.
- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
