### PR TITLE
fix(internal): use `websocket` in favor of `websocket_route`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- [#30](https://github.com/WSH032/fastapi-proxy-lib/pull/30) - fix(internal): use `websocket` in favor of `websocket_route`. Thanks [@WSH032](https://github.com/WSH032)!
+
 ## [0.1.0] - 2023-12-01
 
 ### Security

--- a/src/fastapi_proxy_lib/core/websocket.py
+++ b/src/fastapi_proxy_lib/core/websocket.py
@@ -700,7 +700,7 @@ class ReverseWebSocketProxy(BaseWebSocketProxy):
 
     app = FastAPI(lifespan=close_proxy_event)
 
-    @app.websocket_route("/{path:path}")
+    @app.websocket("/{path:path}")
     async def _(websocket: WebSocket, path: str = ""):
         return await proxy.proxy(websocket=websocket, path=path)
 

--- a/tests/app/echo_ws_app.py
+++ b/tests/app/echo_ws_app.py
@@ -19,7 +19,7 @@ def get_app() -> AppDataclass4Test:  # noqa: C901, PLR0915
     request_dict = RequestDict(request=None)
     test_app_dataclass = AppDataclass4Test(app=app, request_dict=request_dict)
 
-    @app.websocket_route("/echo_text")
+    @app.websocket("/echo_text")
     async def echo_text(websocket: WebSocket):
         """Websocket endpoint for echo text. Just receive text and send it back.
 
@@ -36,7 +36,7 @@ def get_app() -> AppDataclass4Test:  # noqa: C901, PLR0915
             except WebSocketDisconnect:
                 break
 
-    @app.websocket_route("/echo_bytes")
+    @app.websocket("/echo_bytes")
     async def echo_bytes(websocket: WebSocket):
         """Websocket endpoint for echo bytes. Just receive bytes and send it back.
 
@@ -53,7 +53,7 @@ def get_app() -> AppDataclass4Test:  # noqa: C901, PLR0915
             except WebSocketDisconnect:
                 break
 
-    @app.websocket_route("/accept_foo_subprotocol")
+    @app.websocket("/accept_foo_subprotocol")
     async def accept_foo_subprotocol(websocket: WebSocket):
         """When client send subprotocols request, if subprotocols contain "foo", will accept it."""
         nonlocal test_app_dataclass
@@ -69,7 +69,7 @@ def get_app() -> AppDataclass4Test:  # noqa: C901, PLR0915
 
         await websocket.close()
 
-    @app.websocket_route("/just_close_with_1001")
+    @app.websocket("/just_close_with_1001")
     async def just_close_with_1001(websocket: WebSocket):
         """Just do nothing after `accept`, then close ws with 1001 code."""
         nonlocal test_app_dataclass
@@ -79,7 +79,7 @@ def get_app() -> AppDataclass4Test:  # noqa: C901, PLR0915
         await asyncio.sleep(0.3)
         await websocket.close(1001)
 
-    @app.websocket_route("/reject_handshake")
+    @app.websocket("/reject_handshake")
     async def reject_handshake(websocket: WebSocket):
         """Will reject ws request by just calling `websocket.close()`."""
         nonlocal test_app_dataclass
@@ -87,7 +87,7 @@ def get_app() -> AppDataclass4Test:  # noqa: C901, PLR0915
 
         await websocket.close()
 
-    @app.websocket_route("/do_nothing")
+    @app.websocket("/do_nothing")
     async def do_nothing(websocket: WebSocket):
         """Will do nothing except `websocket.accept()`."""
         nonlocal test_app_dataclass

--- a/tests/test_docs_examples.py
+++ b/tests/test_docs_examples.py
@@ -89,7 +89,7 @@ def test_reverse_ws_proxy() -> None:
 
     app = FastAPI(lifespan=close_proxy_event)
 
-    @app.websocket_route("/{path:path}")
+    @app.websocket("/{path:path}")
     async def _(websocket: WebSocket, path: str = ""):
         return await proxy.proxy(websocket=websocket, path=path)
 


### PR DESCRIPTION
# Summary

The `websocket_route` is a legacy API of FastAPI, which we mistakenly used before. The `websocket` we are currently using serves as a full replacement for the former.

