### PR TITLE
feat: support `anyio`, sending denial response, handshake headers

### DIFF
--- a/docs/Usage/FastAPI-Helper.md
+++ b/docs/Usage/FastAPI-Helper.md
@@ -29,7 +29,7 @@ app = reverse_http_app(client=client, base_url=base_url)
 ```
 
 1. You can pass `httpx.AsyncClient` instance:
-    - if you want to customize the arguments, e.g. `httpx.AsyncClient(proxies={})`
+    - if you want to customize the arguments, e.g. `httpx.AsyncClient(http2=True)`
     - if you want to reuse the connection pool of `httpx.AsyncClient`
     ---
     Or you can pass `None`(The default value), then `fastapi-proxy-lib` will create a new `httpx.AsyncClient` instance for you.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,9 +50,11 @@ dynamic = ["version"]
 
 dependencies = [
     "httpx",
-    "httpx-ws >= 0.4.2",
+    "httpx-ws >= 0.5.2",
     "starlette",
     "typing_extensions >=4.5.0",
+    "anyio >= 4",
+    "exceptiongroup",
 ]
 
 [project.optional-dependencies]
@@ -97,7 +99,6 @@ dependencies = [
     "pytest-cov ==  4.*",
     "uvicorn[standard] < 1.0.0", # TODO: Once it releases version 1.0.0, we will remove this restriction.
     "httpx[http2]",              # we don't set version here, instead set it in `[project].dependencies`.
-    "anyio",                     # we don't set version here, because fastapi has a dependency on it
     "asgi-lifespan==2.*",
     "pytest-timeout==2.*",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,8 +50,8 @@ dynamic = ["version"]
 
 dependencies = [
     "httpx",
-    "httpx-ws >= 0.5.2",
-    "starlette",
+    "httpx-ws >= 0.6.0",
+    "starlette >= 0.37.2",
     "typing_extensions >=4.5.0",
     "anyio >= 4",
     "exceptiongroup",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,9 +98,11 @@ dependencies = [
     "pytest == 7.*",
     "pytest-cov ==  4.*",
     "uvicorn[standard] < 1.0.0", # TODO: Once it releases version 1.0.0, we will remove this restriction.
+    "hypercorn[trio] == 0.16.*",
     "httpx[http2]",              # we don't set version here, instead set it in `[project].dependencies`.
-    "asgi-lifespan==2.*",
-    "pytest-timeout==2.*",
+    "asgi-lifespan == 2.*",
+    "pytest-timeout == 2.*",
+    "sniffio == 1.3.*",
 ]
 
 [tool.hatch.envs.default.scripts]

--- a/src/fastapi_proxy_lib/core/_tool.py
+++ b/src/fastapi_proxy_lib/core/_tool.py
@@ -309,8 +309,8 @@ def return_err_msg_response(
     err_response_json = ErrRseponseJson(detail=detail)
 
     # TODO: 请注意，logging是同步函数，每次会阻塞1ms左右，这可能会导致性能问题
-    # 特别是对于写入文件的log，最好把它放到 asyncio.to_thread 里执行
-    # https://docs.python.org/zh-cn/3/library/asyncio-task.html#coroutine
+    # 特别是对于写入文件的log，最好把它放到 `anyio.to_thread.run_sync()` 里执行
+    # https://anyio.readthedocs.io/en/stable/threads.html#running-a-function-in-a-worker-thread
 
     if logger is not None:
         # 只要传入了logger，就一定记录日志

--- a/src/fastapi_proxy_lib/core/_tool.py
+++ b/src/fastapi_proxy_lib/core/_tool.py
@@ -1,13 +1,11 @@
 """The utils tools for both http proxy and websocket proxy."""
 
 import ipaddress
-import logging
 import warnings
 from functools import lru_cache
 from textwrap import dedent
 from typing import (
     Any,
-    Iterable,
     Mapping,
     Optional,
     Protocol,
@@ -17,7 +15,6 @@ from typing import (
 )
 
 import httpx
-from starlette import status
 from starlette.background import BackgroundTask as BackgroundTask_t
 from starlette.datastructures import (
     Headers as StarletteHeaders,
@@ -26,13 +23,11 @@ from starlette.datastructures import (
     MutableHeaders as StarletteMutableHeaders,
 )
 from starlette.responses import JSONResponse
-from starlette.types import Scope
 from typing_extensions import deprecated, overload
 
 __all__ = (
     "check_base_url",
     "return_err_msg_response",
-    "check_http_version",
     "BaseURLError",
     "ErrMsg",
     "ErrRseponseJson",
@@ -127,10 +122,6 @@ class BaseURLError(ValueError):
 
 class _RejectedProxyRequestError(RuntimeError):
     """Should be raised when reject proxy request."""
-
-
-class _UnsupportedHttpVersionError(RuntimeError):
-    """Unsupported http version."""
 
 
 #################### Tools ####################
@@ -335,35 +326,6 @@ def return_err_msg_response(
         headers=headers,
         background=background,
     )
-
-
-def check_http_version(
-    scope: Scope, supported_versions: Iterable[str]
-) -> Union[JSONResponse, None]:
-    """Check whether the http version of scope is in supported_versions.
-
-    Args:
-        scope: asgi scope dict.
-        supported_versions: The supported http versions.
-
-    Returns:
-        If the http version of scope is not in supported_versions, return a JSONResponse with status_code=505,
-        else return None.
-    """
-    # https://asgi.readthedocs.io/en/latest/specs/www.html#http-connection-scope
-    # https://asgi.readthedocs.io/en/latest/specs/www.html#websocket-connection-scope
-    http_version: str = scope.get("http_version", "")
-    # 如果明确指定了http版本（即不是""），但不在支持的版本内，则返回505
-    if http_version not in supported_versions and http_version != "":
-        error = _UnsupportedHttpVersionError(
-            f"The request http version is {http_version}, but we only support {supported_versions}."
-        )
-        # TODO: 或许可以logging记录下 scope.get("client") 的值
-        return return_err_msg_response(
-            error,
-            status_code=status.HTTP_505_HTTP_VERSION_NOT_SUPPORTED,
-            logger=logging.info,
-        )
 
 
 def default_proxy_filter(url: httpx.URL) -> Union[None, str]:

--- a/src/fastapi_proxy_lib/core/websocket.py
+++ b/src/fastapi_proxy_lib/core/websocket.py
@@ -671,8 +671,8 @@ class ReverseWebSocketProxy(BaseWebSocketProxy):
     app = FastAPI(lifespan=close_proxy_event)
 
     @app.websocket("/{path:path}")
-    async def _(websocket: WebSocket, path: str = ""):
-        return await proxy.proxy(websocket=websocket, path=path)
+    async def _(websocket: WebSocket):
+        return await proxy.proxy(websocket=websocket)
 
     # Then run shell: `uvicorn <your.py>:app --host http://127.0.0.1:8000 --port 8000`
     # visit the app: `ws://127.0.0.1:8000/`
@@ -737,15 +737,12 @@ class ReverseWebSocketProxy(BaseWebSocketProxy):
 
     @override
     async def proxy(  # pyright: ignore [reportIncompatibleMethodOverride]
-        self, *, websocket: starlette_ws.WebSocket, path: Optional[str] = None
+        self, *, websocket: starlette_ws.WebSocket
     ) -> Union[Literal[False], StarletteResponse]:
         """Establish websocket connection for both client and target_url, then pass messages between them.
 
         Args:
             websocket: The client websocket requests.
-            path: The path params of websocket request, which means the path params of base url.<br>
-                If None, will get it from `websocket.path_params`.<br>
-                **Usually, you don't need to pass this argument**.
 
         Returns:
             If the establish websocket connection unsuccessfully:
@@ -757,9 +754,7 @@ class ReverseWebSocketProxy(BaseWebSocketProxy):
         base_url = self.base_url
 
         # 只取第一个路径参数。注意，我们允许没有路径参数，这代表直接请求
-        path_param: str = (
-            path if path is not None else next(iter(websocket.path_params.values()), "")
-        )
+        path_param: str = next(iter(websocket.path_params.values()), "")
 
         # 将路径参数拼接到目标url上
         # e.g: "https://www.example.com/p0/" + "p1"

--- a/src/fastapi_proxy_lib/core/websocket.py
+++ b/src/fastapi_proxy_lib/core/websocket.py
@@ -42,7 +42,7 @@ try:
         DEFAULT_MAX_MESSAGE_SIZE_BYTES,
         DEFAULT_QUEUE_SIZE,
     )
-except ImportError:
+except ImportError:  # pragma: no cover
     # ref: https://github.com/frankie567/httpx-ws/blob/b2135792141b71551b022ff0d76542a0263a890c/httpx_ws/_api.py#L31-L34
     DEFAULT_KEEPALIVE_PING_TIMEOUT_SECONDS = (  # pyright: ignore[reportConstantRedefinition]
         20.0

--- a/src/fastapi_proxy_lib/core/websocket.py
+++ b/src/fastapi_proxy_lib/core/websocket.py
@@ -55,14 +55,13 @@ except ImportError:  # pragma: no cover
     )
     DEFAULT_QUEUE_SIZE = 512  # pyright: ignore[reportConstantRedefinition]
 
-    msg = dedent(
-        """\
-        Can not import the default httpx_ws arguments, please open an issue on:
-        https://github.com/WSH032/fastapi-proxy-lib\
-        """
-    )
     warnings.warn(
-        msg,
+        dedent(
+            """\
+            Can not import the default httpx_ws arguments, please open an issue on:
+            https://github.com/WSH032/fastapi-proxy-lib\
+            """
+        ),
         RuntimeWarning,
         stacklevel=1,
     )

--- a/src/fastapi_proxy_lib/fastapi/router.py
+++ b/src/fastapi_proxy_lib/fastapi/router.py
@@ -63,7 +63,7 @@ def _http_register_router(
     @router.patch("/{path:path}", **kwargs)
     @router.trace("/{path:path}", **kwargs)
     async def http_proxy(  # pyright: ignore[reportUnusedFunction]
-        request: Request, path: str = ""
+        request: Request,
     ) -> Response:
         """HTTP proxy endpoint.
 
@@ -74,7 +74,7 @@ def _http_register_router(
         Returns:
             The response from target server.
         """
-        return await proxy.proxy(request=request, path=path)
+        return await proxy.proxy(request=request)
 
 
 def _ws_register_router(
@@ -96,7 +96,7 @@ def _ws_register_router(
 
     @router.websocket("/{path:path}", **kwargs)
     async def ws_proxy(  # pyright: ignore[reportUnusedFunction]
-        websocket: WebSocket, path: str = ""
+        websocket: WebSocket,
     ) -> Union[Response, Literal[False]]:
         """WebSocket proxy endpoint.
 
@@ -111,7 +111,7 @@ def _ws_register_router(
             If the establish websocket connection successfully:
                 - Will run forever until the connection is closed. Then return False.
         """
-        return await proxy.proxy(websocket=websocket, path=path)
+        return await proxy.proxy(websocket=websocket)
 
 
 class RouterHelper:

--- a/src/fastapi_proxy_lib/fastapi/router.py
+++ b/src/fastapi_proxy_lib/fastapi/router.py
@@ -10,7 +10,6 @@ from typing import (
     AsyncContextManager,
     AsyncIterator,
     Callable,
-    Literal,
     Optional,
     Set,
     TypeVar,
@@ -97,7 +96,7 @@ def _ws_register_router(
     @router.websocket("/{path:path}", **kwargs)
     async def ws_proxy(  # pyright: ignore[reportUnusedFunction]
         websocket: WebSocket,
-    ) -> Union[Response, Literal[False]]:
+    ) -> bool:
         """WebSocket proxy endpoint.
 
         Args:
@@ -105,11 +104,7 @@ def _ws_register_router(
             path: The path parameters of request.
 
         Returns:
-            If the establish websocket connection unsuccessfully:
-                - Will call `websocket.close()` to send code `4xx`
-                - Then return a `StarletteResponse` from target server
-            If the establish websocket connection successfully:
-                - Will run forever until the connection is closed. Then return False.
+            bool: If handshake failed, return True. Else return False.
         """
         return await proxy.proxy(websocket=websocket)
 

--- a/tests/app/echo_ws_app.py
+++ b/tests/app/echo_ws_app.py
@@ -87,13 +87,16 @@ def get_app() -> AppDataclass4Test:  # noqa: C901, PLR0915
 
         await websocket.close()
 
-    @app.websocket("/do_nothing")
+    @app.websocket("/receive_and_send_text_once_without_closing")
     async def do_nothing(websocket: WebSocket):
-        """Will do nothing except `websocket.accept()`."""
+        """Will receive text once and send it back once, without closing ws."""
         nonlocal test_app_dataclass
         test_app_dataclass.request_dict["request"] = websocket
 
         await websocket.accept()
+
+        recev = await websocket.receive_text()
+        await websocket.send_text(recev)
 
     return test_app_dataclass
 

--- a/tests/app/echo_ws_app.py
+++ b/tests/app/echo_ws_app.py
@@ -1,8 +1,8 @@
 # ruff: noqa: D100
 # pyright: reportUnusedFunction=false
 
-import asyncio
 
+import anyio
 from fastapi import FastAPI, WebSocket
 from starlette.websockets import WebSocketDisconnect
 
@@ -76,7 +76,7 @@ def get_app() -> AppDataclass4Test:  # noqa: C901, PLR0915
         test_app_dataclass.request_dict["request"] = websocket
 
         await websocket.accept()
-        await asyncio.sleep(0.3)
+        await anyio.sleep(0.3)
         await websocket.close(1001)
 
     @app.websocket("/reject_handshake")

--- a/tests/app/tool.py
+++ b/tests/app/tool.py
@@ -258,6 +258,7 @@ class AutoServer:
 
         self._exit_stack = AsyncExitStack()
         await self._exit_stack.enter_async_context(self.server)
+        await anyio.sleep(0.5)  # XXX, HACK: wait for server to start
         return self
 
     async def __aexit__(self, *_: Any, **__: Any) -> None:

--- a/tests/app/tool.py
+++ b/tests/app/tool.py
@@ -1,18 +1,16 @@
 # noqa: D100
 
-import asyncio
-import socket
+from contextlib import AsyncExitStack
 from dataclasses import dataclass
-from typing import Any, Callable, List, Optional, Type, TypedDict, TypeVar, Union
+from typing import Any, TypedDict, Union
 
+import anyio
 import httpx
 import uvicorn
 from fastapi import FastAPI
 from starlette.requests import Request
 from starlette.websockets import WebSocket
-from typing_extensions import Self, override
-
-_Decoratable_T = TypeVar("_Decoratable_T", bound=Union[Callable[..., Any], Type[Any]])
+from typing_extensions import Self
 
 ServerRecvRequestsTypes = Union[Request, WebSocket]
 
@@ -46,180 +44,32 @@ class AppDataclass4Test:
         return server_recv_request
 
 
-def _no_override_uvicorn_server(_method: _Decoratable_T) -> _Decoratable_T:
-    """Check if the method is already in `uvicorn.Server`."""
-    assert not hasattr(
-        uvicorn.Server, _method.__name__
-    ), f"Override method of `uvicorn.Server` cls : {_method.__name__}"
-    return _method
-
-
-class AeixtTimeoutUndefine:
-    """Didn't set `contx_exit_timeout` in `aexit()`."""
-
-
-aexit_timeout_undefine = AeixtTimeoutUndefine()
-
-
-# HACK: 不能继承 AbstractAsyncContextManager[Self]
-# 目前有问题，继承 AbstractAsyncContextManager 的话pyright也推测不出来类型
-# 只能依靠 __aenter__ 和 __aexit__ 的类型注解
 class UvicornServer(uvicorn.Server):
-    """subclass of `uvicorn.Server` which can use AsyncContext to launch and shutdown automatically.
+    """subclass of `uvicorn.Server` which can use AsyncContext to launch and shutdown automatically."""
 
-    Attributes:
-        contx_server_task: The task of server.
-        contx_socket: The socket of server.
-
-        other attributes are same as `uvicorn.Server`:
-            - config: The config arg that be passed in.
-            ...
-    """
-
-    _contx_server_task: Union["asyncio.Task[None]", None]
-    assert not hasattr(uvicorn.Server, "_contx_server_task")
-
-    _contx_socket: Union[socket.socket, None]
-    assert not hasattr(uvicorn.Server, "_contx_socket")
-
-    _contx_server_started_event: Union[asyncio.Event, None]
-    assert not hasattr(uvicorn.Server, "_contx_server_started_event")
-
-    contx_exit_timeout: Union[int, float, None]
-    assert not hasattr(uvicorn.Server, "contx_exit_timeout")
-
-    @override
-    def __init__(
-        self, config: uvicorn.Config, contx_exit_timeout: Union[int, float, None] = None
-    ) -> None:
-        """The same as `uvicorn.Server.__init__`."""
-        super().__init__(config=config)
-        self._contx_server_task = None
-        self._contx_socket = None
-        self._contx_server_started_event = None
-        self.contx_exit_timeout = contx_exit_timeout
-
-    @override
-    async def startup(self, sockets: Optional[List[socket.socket]] = None) -> None:
-        """The same as `uvicorn.Server.startup`."""
-        super_return = await super().startup(sockets=sockets)
-        self.contx_server_started_event.set()
-        return super_return
-
-    @_no_override_uvicorn_server
-    async def aenter(self) -> Self:
+    async def __aenter__(self) -> Self:
         """Launch the server."""
-        # 在分配资源之前，先检查是否重入
-        if self.contx_server_started_event.is_set():
-            raise RuntimeError("DO not launch server by __aenter__ again!")
-
         # FIXME: # 这个socket被设计为可被同一进程内的多个server共享，可能会引起潜在问题
-        self._contx_socket = self.config.bind_socket()
+        self._socket = self.config.bind_socket()
+        self._exit_stack = AsyncExitStack()
 
-        self._contx_server_task = asyncio.create_task(
-            self.serve([self._contx_socket]), name=f"Uvicorn Server Task of {self}"
+        task_group = await self._exit_stack.enter_async_context(
+            anyio.create_task_group()
         )
-        # 在 uvicorn.Server 的实现中，Server.serve() 内部会调用 Server.startup() 完成启动
-        # 被覆盖的 self.startup() 会在完成时调用 self.contx_server_started_event.set()
-        await self.contx_server_started_event.wait()  # 等待服务器确实启动后才返回
+        task_group.start_soon(
+            self.serve, [self._socket], name=f"Uvicorn Server Task of {self}"
+        )
+
         return self
 
-    @_no_override_uvicorn_server
-    async def __aenter__(self) -> Self:
-        """Launch the server.
-
-        The same as `self.aenter()`.
-        """
-        return await self.aenter()
-
-    @_no_override_uvicorn_server
-    async def aexit(
-        self,
-        contx_exit_timeout: Union[
-            int, float, None, AeixtTimeoutUndefine
-        ] = aexit_timeout_undefine,
-    ) -> None:
-        """Shutdown the server."""
-        contx_server_task = self.contx_server_task
-        contx_socket = self.contx_socket
-
-        if isinstance(contx_exit_timeout, AeixtTimeoutUndefine):
-            contx_exit_timeout = self.contx_exit_timeout
-
-        # 在 uvicorn.Server 的实现中，设置 should_exit 可以使得 server 任务结束
-        assert hasattr(self, "should_exit")
-        self.should_exit = True
-
-        try:
-            await asyncio.wait_for(contx_server_task, timeout=contx_exit_timeout)
-        except asyncio.TimeoutError:
-            print(f"{contx_server_task.get_name()} timeout!")
-        finally:
-            # 其实uvicorn.Server会自动关闭socket，这里是为了保险起见
-            contx_socket.close()
-
-    @_no_override_uvicorn_server
     async def __aexit__(self, *_: Any, **__: Any) -> None:
-        """Shutdown the server.
-
-        The same as `self.aexit()`.
-        """
-        return await self.aexit()
-
-    @property
-    @_no_override_uvicorn_server
-    def contx_server_started_event(self) -> asyncio.Event:
-        """The event that indicates the server has started.
-
-        When first call the property, it will instantiate a `asyncio.Event()`to
-        `self._contx_server_started_event`.
-
-        Warn: This is a internal implementation detail, do not change the event manually.
-            - please call the property in `self.aenter()` or `self.startup()` **first**.
-            - **Never** call it outside of an async event loop first:
-                https://stackoverflow.com/questions/53724665/using-queues-results-in-asyncio-exception-got-future-future-pending-attached
-        """
-        if self._contx_server_started_event is None:
-            self._contx_server_started_event = asyncio.Event()
-
-        return self._contx_server_started_event
+        """Shutdown the server."""
+        # 在 uvicorn.Server 的实现中，设置 should_exit 可以使得 server 任务结束
+        assert self.should_exit is False, "The server has already exited."
+        self.should_exit = True
+        await self._exit_stack.__aexit__(*_, **__)
 
     @property
-    @_no_override_uvicorn_server
-    def contx_socket(self) -> socket.socket:
-        """The socket of server.
-
-        Note: must call `self.__aenter__()` first.
-        """
-        if self._contx_socket is None:
-            raise RuntimeError("Please call `self.__aenter__()` first.")
-        else:
-            return self._contx_socket
-
-    @property
-    @_no_override_uvicorn_server
-    def contx_server_task(self) -> "asyncio.Task[None]":
-        """The task of server.
-
-        Note: must call `self.__aenter__()` first.
-        """
-        if self._contx_server_task is None:
-            raise RuntimeError("Please call `self.__aenter__()` first.")
-        else:
-            return self._contx_server_task
-
-    @property
-    @_no_override_uvicorn_server
-    def contx_socket_getname(self) -> Any:
-        """Utils for calling self.contx_socket.getsockname().
-
-        Return:
-            refer to: https://docs.python.org/zh-cn/3/library/socket.html#socket-families
-        """
-        return self.contx_socket.getsockname()
-
-    @property
-    @_no_override_uvicorn_server
     def contx_socket_url(self) -> httpx.URL:
         """If server is tcp socket, return the url of server.
 
@@ -228,7 +78,8 @@ class UvicornServer(uvicorn.Server):
         config = self.config
         if config.fd is not None or config.uds is not None:
             raise RuntimeError("Only support tcp socket.")
-        host, port = self.contx_socket_getname[:2]
+        # refer to: https://docs.python.org/zh-cn/3/library/socket.html#socket-families
+        host, port = self._socket.getsockname()[:2]
         return httpx.URL(
             host=host,
             port=port,

--- a/tests/app/tool.py
+++ b/tests/app/tool.py
@@ -2,12 +2,23 @@
 
 from contextlib import AsyncExitStack
 from dataclasses import dataclass
-from typing import Any, TypedDict, Union
+from typing import Any, Literal, TypedDict, Union
 
 import anyio
 import httpx
+import sniffio
 import uvicorn
 from fastapi import FastAPI
+from hypercorn import Config as HyperConfig
+from hypercorn.asyncio.run import (
+    worker_serve as hyper_aio_serve,  # pyright: ignore[reportUnknownVariableType]
+)
+from hypercorn.trio.run import (
+    worker_serve as hyper_trio_serve,  # pyright: ignore[reportUnknownVariableType]
+)
+from hypercorn.utils import (
+    wrap_app as hyper_wrap_app,  # pyright: ignore[reportUnknownVariableType]
+)
 from starlette.requests import Request
 from starlette.websockets import WebSocket
 from typing_extensions import Self
@@ -65,7 +76,7 @@ class UvicornServer(uvicorn.Server):
     async def __aexit__(self, *_: Any, **__: Any) -> None:
         """Shutdown the server."""
         # 在 uvicorn.Server 的实现中，设置 should_exit 可以使得 server 任务结束
-        assert self.should_exit is False, "The server has already exited."
+        assert not self.should_exit, "The server has already exited."
         self.should_exit = True
         await self._exit_stack.__aexit__(*_, **__)
 
@@ -86,3 +97,129 @@ class UvicornServer(uvicorn.Server):
             scheme="https" if config.is_ssl else "http",
             path="/",
         )
+
+
+class HypercornServer:
+    """An AsyncContext to launch and shutdown Hypercorn server automatically."""
+
+    def __init__(self, app: FastAPI, config: HyperConfig):  # noqa: D107
+        self.config = config
+        self.app = app
+        self.should_exit = anyio.Event()
+
+    async def __aenter__(self) -> Self:
+        """Launch the server."""
+        self._sockets = self.config.create_sockets()
+        self._exit_stack = AsyncExitStack()
+
+        self.current_async_lib = sniffio.current_async_library()
+
+        if self.current_async_lib == "asyncio":
+            serve_func = hyper_aio_serve  # pyright: ignore[reportUnknownVariableType]
+        elif self.current_async_lib == "trio":
+            serve_func = hyper_trio_serve  # pyright: ignore[reportUnknownVariableType]
+        else:
+            raise RuntimeError(f"Unsupported async library {self.current_async_lib!r}")
+
+        async def serve() -> None:
+            # Implement ref:
+            #   https://github.com/pgjones/hypercorn/blob/3fbd5f245e5dfeaba6ad852d9135d6a32b228d05/src/hypercorn/asyncio/__init__.py#L12-L46
+            #   https://github.com/pgjones/hypercorn/blob/3fbd5f245e5dfeaba6ad852d9135d6a32b228d05/src/hypercorn/trio/__init__.py#L14-L52
+            await serve_func(
+                hyper_wrap_app(
+                    self.app,  # pyright: ignore[reportArgumentType]
+                    self.config.wsgi_max_body_size,
+                    mode=None,
+                ),
+                self.config,
+                shutdown_trigger=self.should_exit.wait,
+            )
+
+        task_group = await self._exit_stack.enter_async_context(
+            anyio.create_task_group()
+        )
+        task_group.start_soon(serve, name=f"Hypercorn Server Task of {self}")
+        return self
+
+    async def __aexit__(self, *_: Any, **__: Any) -> None:
+        """Shutdown the server."""
+        assert not self.should_exit.is_set(), "The server has already exited."
+        self.should_exit.set()
+        await self._exit_stack.__aexit__(*_, **__)
+
+    @property
+    def contx_socket_url(self) -> httpx.URL:
+        """If server is tcp socket, return the url of server.
+
+        Note: The path of url is explicitly set to "/".
+        """
+        config = self.config
+
+        bind = config.bind[0]
+        if bind.startswith(("unix:", "fd://")):
+            raise RuntimeError("Only support tcp socket.")
+
+        # refer to: https://docs.python.org/zh-cn/3/library/socket.html#socket-families
+        host, port = config.bind[0].split(":")
+        port = int(port)
+
+        return httpx.URL(
+            host=host,
+            port=port,
+            scheme="https" if config.ssl_enabled else "http",
+            path="/",
+        )
+
+
+class TestServer:
+    """An AsyncContext to launch and shutdown Hypercorn or Uvicorn server automatically."""
+
+    def __init__(
+        self,
+        app: FastAPI,
+        host: str,
+        port: int,
+        server_type: Literal["uvicorn", "hypercorn"] = "hypercorn",
+    ):
+        """Only support ipv4 address.
+
+        If use uvicorn, it only support asyncio backend.
+        """
+        self.app = app
+        self.host = host
+        self.port = port
+        self.server_type = server_type
+
+        if self.server_type == "hypercorn":
+            config = HyperConfig()
+            config.bind = f"{host}:{port}"
+
+            self.config = config
+            self.server = HypercornServer(app, config)
+        else:
+            self.config = uvicorn.Config(app, host=host, port=port)
+            self.server = UvicornServer(self.config)
+
+    async def __aenter__(self) -> Self:
+        """Launch the server."""
+        if (
+            self.server_type == "uvicorn"
+            and sniffio.current_async_library() != "asyncio"
+        ):
+            raise RuntimeError("Uvicorn server does not support trio backend.")
+
+        self._exit_stack = AsyncExitStack()
+        await self._exit_stack.enter_async_context(self.server)
+        return self
+
+    async def __aexit__(self, *_: Any, **__: Any) -> None:
+        """Shutdown the server."""
+        await self._exit_stack.__aexit__(*_, **__)
+
+    @property
+    def contx_socket_url(self) -> httpx.URL:
+        """If server is tcp socket, return the url of server.
+
+        Note: The path of url is explicitly set to "/".
+        """
+        return self.server.contx_socket_url

--- a/tests/app/tool.py
+++ b/tests/app/tool.py
@@ -213,7 +213,7 @@ class _HypercornServer:
         )
 
 
-class TestServer:
+class AutoServer:
     """An AsyncContext to launch and shutdown Hypercorn or Uvicorn server automatically."""
 
     def __init__(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,7 @@ from typing_extensions import ParamSpec
 
 from .app.echo_http_app import get_app as get_http_test_app
 from .app.echo_ws_app import get_app as get_ws_test_app
-from .app.tool import AppDataclass4Test, TestServer
+from .app.tool import AppDataclass4Test, AutoServer
 
 # ASGI types.
 # Copied from: https://github.com/florimondmanca/asgi-lifespan/blob/fbb0f440337314be97acaae1a3c0c7a2ec8298dd/src/asgi_lifespan/_types.py
@@ -62,14 +62,14 @@ AppFactoryFixture = Callable[..., Coroutine[None, None, ASGIApp]]
 """The lifespan of app will be managed automatically by pytest."""
 
 
-class TestServerFixture(Protocol):  # noqa: D101
+class AutoServerFixture(Protocol):  # noqa: D101
     def __call__(  # noqa: D102
         self,
         app: FastAPI,
         host: str,
         port: int,
         server_type: Optional[Literal["uvicorn", "hypercorn"]] = None,
-    ) -> Coroutine[None, None, TestServer]: ...
+    ) -> Coroutine[None, None, AutoServer]: ...
 
 
 # https://anyio.readthedocs.io/en/stable/testing.html#specifying-the-backends-to-run-on
@@ -203,22 +203,22 @@ def reverse_ws_app_fct(
 
 
 @pytest.fixture()
-async def test_server_fixture() -> AsyncIterator[TestServerFixture]:
-    """Fixture for TestServer.
+async def auto_server_fixture() -> AsyncIterator[AutoServerFixture]:
+    """Fixture for AutoServer.
 
     Will launch and shutdown automatically.
     """
     async with AsyncExitStack() as exit_stack:
 
-        async def test_server_fct(
+        async def auto_server_fct(
             app: FastAPI,
             host: str,
             port: int,
             server_type: Optional[Literal["uvicorn", "hypercorn"]] = None,
-        ) -> TestServer:
-            test_server = await exit_stack.enter_async_context(
-                TestServer(app=app, host=host, port=port, server_type=server_type)
+        ) -> AutoServer:
+            auto_server = await exit_stack.enter_async_context(
+                AutoServer(app=app, host=host, port=port, server_type=server_type)
             )
-            return test_server
+            return auto_server
 
-        yield test_server_fct
+        yield auto_server_fct

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,6 @@ from typing import (
     Coroutine,
     Literal,
     Protocol,
-    Union,
 )
 
 import pytest
@@ -64,7 +63,7 @@ AppFactoryFixture = Callable[..., Coroutine[None, None, ASGIApp]]
 
 class UvicornServerFixture(Protocol):  # noqa: D101
     def __call__(  # noqa: D102
-        self, config: uvicorn.Config, contx_exit_timeout: Union[int, float, None] = None
+        self, config: uvicorn.Config
     ) -> Coroutine[None, None, UvicornServer]: ...
 
 
@@ -199,11 +198,9 @@ async def uvicorn_server_fixture() -> AsyncIterator[UvicornServerFixture]:
     """
     async with AsyncExitStack() as exit_stack:
 
-        async def uvicorn_server_fct(
-            config: uvicorn.Config, contx_exit_timeout: Union[int, float, None] = None
-        ) -> UvicornServer:
+        async def uvicorn_server_fct(config: uvicorn.Config) -> UvicornServer:
             uvicorn_server = await exit_stack.enter_async_context(
-                UvicornServer(config=config, contx_exit_timeout=contx_exit_timeout)
+                UvicornServer(config=config)
             )
             return uvicorn_server
 

--- a/tests/test_core_lib.py
+++ b/tests/test_core_lib.py
@@ -70,7 +70,10 @@ async def test_func_return_err_msg_response() -> None:
     #     }
     # }
 
-    client = httpx.AsyncClient(app=app, base_url="http://www.example.com")
+    client = httpx.AsyncClient(
+        transport=httpx.ASGITransport(app),  # pyright: ignore[reportArgumentType]
+        base_url="http://www.example.com",
+    )
     resp = await client.get("http://www.example.com/exception")
     assert resp.status_code == 0
     assert resp.json()["detail"] == test_err_msg

--- a/tests/test_docs_examples.py
+++ b/tests/test_docs_examples.py
@@ -23,8 +23,8 @@ def test_forward_http_proxy() -> None:
     app = FastAPI(lifespan=close_proxy_event)
 
     @app.get("/{path:path}")
-    async def _(request: Request, path: str = ""):
-        return await proxy.proxy(request=request, path=path)
+    async def _(request: Request):
+        return await proxy.proxy(request=request)
 
     # Then run shell: `uvicorn <your.py>:app --host http://127.0.0.1:8000 --port 8000`
     # visit the app: `http://127.0.0.1:8000/http://www.example.com`
@@ -52,8 +52,8 @@ def test_reverse_http_proxy() -> None:
     app = FastAPI(lifespan=close_proxy_event)
 
     @app.get("/{path:path}")  # (2)!
-    async def _(request: Request, path: str = ""):
-        return await proxy.proxy(request=request, path=path)  # (3)!
+    async def _(request: Request):
+        return await proxy.proxy(request=request)  # (3)!
 
     # Then run shell: `uvicorn <your.py>:app --host http://127.0.0.1:8000 --port 8000`
     # visit the app: `http://127.0.0.1:8000/`
@@ -62,11 +62,7 @@ def test_reverse_http_proxy() -> None:
     """ 1. lifespan please refer to [starlette/lifespan](https://www.starlette.io/lifespan/)
     2. `{path:path}` is the key.<br>
         It allows the app to accept all path parameters.<br>
-        visit <https://www.starlette.io/routing/#path-parameters> for more info.
-    3. !!! info
-        In fact, you only need to pass the `request: Request` argument.<br>
-        `fastapi_proxy_lib` can automatically get the `path` from `request`.<br>
-        Explicitly pointing it out here is just to remind you not to forget to specify `{path:path}`. """
+        visit <https://www.starlette.io/routing/#path-parameters> for more info. """
 
 
 def test_reverse_ws_proxy() -> None:
@@ -90,8 +86,8 @@ def test_reverse_ws_proxy() -> None:
     app = FastAPI(lifespan=close_proxy_event)
 
     @app.websocket("/{path:path}")
-    async def _(websocket: WebSocket, path: str = ""):
-        return await proxy.proxy(websocket=websocket, path=path)
+    async def _(websocket: WebSocket):
+        return await proxy.proxy(websocket=websocket)
 
     # Then run shell: `uvicorn <your.py>:app --host http://127.0.0.1:8000 --port 8000`
     # visit the app: `ws://127.0.0.1:8000/`

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -32,7 +32,10 @@ class TestReverseHttpProxy(AbstractTestProxy):
     ) -> Tool4TestFixture:
         """目标服务器请参考`tests.app.echo_http_app.get_app`."""
         client_for_conn_to_target_server = httpx.AsyncClient(
-            app=echo_http_test_model.app, base_url=DEFAULT_TARGET_SERVER_BASE_URL
+            transport=httpx.ASGITransport(
+                echo_http_test_model.app  # pyright: ignore[reportArgumentType]
+            ),
+            base_url=DEFAULT_TARGET_SERVER_BASE_URL,
         )
 
         reverse_http_app = await reverse_http_app_fct(
@@ -41,7 +44,10 @@ class TestReverseHttpProxy(AbstractTestProxy):
         )
 
         client_for_conn_to_proxy_server = httpx.AsyncClient(
-            app=reverse_http_app, base_url=DEFAULT_PROXY_SERVER_BASE_URL
+            transport=httpx.ASGITransport(
+                reverse_http_app  # pyright: ignore[reportArgumentType]
+            ),
+            base_url=DEFAULT_PROXY_SERVER_BASE_URL,
         )
 
         get_request = echo_http_test_model.get_request
@@ -198,7 +204,10 @@ class TestReverseHttpProxy(AbstractTestProxy):
         )
 
         client_for_conn_to_proxy_server = httpx.AsyncClient(
-            app=reverse_http_app, base_url=DEFAULT_PROXY_SERVER_BASE_URL
+            transport=httpx.ASGITransport(
+                reverse_http_app  # pyright: ignore[reportArgumentType]
+            ),
+            base_url=DEFAULT_PROXY_SERVER_BASE_URL,
         )
 
         r = await client_for_conn_to_proxy_server.get(DEFAULT_PROXY_SERVER_BASE_URL)
@@ -233,9 +242,9 @@ class TestReverseHttpProxy(AbstractTestProxy):
         assert not client_for_conn_to_proxy_server.cookies
 
         # check if cookie is not leaked
+        client_for_conn_to_proxy_server.cookies.set("a", "b")
         r = await client_for_conn_to_proxy_server.get(
-            proxy_server_base_url + "get/cookies",
-            cookies={"a": "b"},
+            proxy_server_base_url + "get/cookies"
         )
         assert "foo" not in r.json()  # not leaked
         assert r.json()["a"] == "b"  # send cookies normally
@@ -252,7 +261,10 @@ class TestForwardHttpProxy(AbstractTestProxy):
     ) -> Tool4TestFixture:
         """目标服务器请参考`tests.app.echo_http_app.get_app`."""
         client_for_conn_to_target_server = httpx.AsyncClient(
-            app=echo_http_test_model.app, base_url=DEFAULT_TARGET_SERVER_BASE_URL
+            transport=httpx.ASGITransport(
+                echo_http_test_model.app  # pyright: ignore[reportArgumentType]
+            ),
+            base_url=DEFAULT_TARGET_SERVER_BASE_URL,
         )
 
         forward_http_app = await forward_http_app_fct(
@@ -260,7 +272,10 @@ class TestForwardHttpProxy(AbstractTestProxy):
         )
 
         client_for_conn_to_proxy_server = httpx.AsyncClient(
-            app=forward_http_app, base_url=DEFAULT_PROXY_SERVER_BASE_URL
+            transport=httpx.ASGITransport(
+                forward_http_app  # pyright: ignore[reportArgumentType]
+            ),
+            base_url=DEFAULT_PROXY_SERVER_BASE_URL,
         )
 
         get_request = echo_http_test_model.get_request
@@ -310,7 +325,10 @@ class TestForwardHttpProxy(AbstractTestProxy):
         )
 
         client_for_conn_to_proxy_server = httpx.AsyncClient(
-            app=forward_http_app, base_url=DEFAULT_PROXY_SERVER_BASE_URL
+            transport=httpx.ASGITransport(
+                forward_http_app  # pyright: ignore[reportArgumentType]
+            ),
+            base_url=DEFAULT_PROXY_SERVER_BASE_URL,
         )
 
         # 错误的无法发出请求的URL
@@ -356,7 +374,10 @@ class TestForwardHttpProxy(AbstractTestProxy):
         )
 
         client_for_conn_to_proxy_server = httpx.AsyncClient(
-            app=forward_http_app, base_url=DEFAULT_PROXY_SERVER_BASE_URL
+            transport=httpx.ASGITransport(
+                forward_http_app  # pyright: ignore[reportArgumentType]
+            ),
+            base_url=DEFAULT_PROXY_SERVER_BASE_URL,
         )
 
         r = await client_for_conn_to_proxy_server.get(
@@ -385,7 +406,9 @@ class TestForwardHttpProxy(AbstractTestProxy):
         )
 
         client_for_conn_to_proxy_server = httpx.AsyncClient(
-            app=forward_http_app,
+            transport=httpx.ASGITransport(
+                forward_http_app
+            ),  # pyright: ignore[reportArgumentType]
             base_url=proxy_server_base_url,
             http2=True,
             http1=False,


### PR DESCRIPTION
# Summary

## Added

- support asyncio and [Trio](https://trio.readthedocs.io/) through [AnyIO](https://anyio.readthedocs.io/)
- support sending [websocket denial response](https://www.starlette.io/websockets/#send-denial-response)
- support sending headers during websocket handshake
- add tests for [hypercorn ](https://github.com/pgjones/hypercorn)server

## Changed

- [remove path parameter in proxy method](https://github.com/WSH032/fastapi-proxy-lib/commit/11f9ff93f585e323191b287f0056c6e010c2cdad)
- the return signature of `ReverseWebSocketProxy.proxy` has been changed;
    it no longer returns `StarletteResponse`, but instead returns `True`

## Test

- [fix the warnings in the tests by not using deprecated APIs from `httpx`](https://github.com/WSH032/fastapi-proxy-lib/commit/8f0ba1fe7aac110d77731e3d591e905321f6f32b) 


# Checklist

- [x] I've read `CONTRIBUTING.md`.
- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
