### PR TITLE
fix: don't use module-level logging methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#30](https://github.com/WSH032/fastapi-proxy-lib/pull/30) - fix(internal): use `websocket` in favor of `websocket_route`. Thanks [@WSH032](https://github.com/WSH032)!
 
+### Fixed
+
+- [#46](https://github.com/WSH032/fastapi-proxy-lib/pull/46) - fix: don't use module-level logging methods. Thanks [@dvarrazzo](https://github.com/dvarrazzo)
+
 ### Internal
 
 - [#47](https://github.com/WSH032/fastapi-proxy-lib/pull/47) - test: do not use deprecated and removed APIs of httpx. Thanks [@WSH032](https://github.com/WSH032)!

--- a/src/fastapi_proxy_lib/core/_tool.py
+++ b/src/fastapi_proxy_lib/core/_tool.py
@@ -44,7 +44,7 @@ __all__ = (
     "_RejectedProxyRequestError",
 )
 
-logger = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 #################### Constant ####################
 
@@ -364,7 +364,7 @@ def check_http_version(
         return return_err_msg_response(
             error,
             status_code=status.HTTP_505_HTTP_VERSION_NOT_SUPPORTED,
-            logger=logger.info,
+            logger=_logger.info,
         )
 
 

--- a/src/fastapi_proxy_lib/core/_tool.py
+++ b/src/fastapi_proxy_lib/core/_tool.py
@@ -44,6 +44,8 @@ __all__ = (
     "_RejectedProxyRequestError",
 )
 
+logger = logging.getLogger(__name__)
+
 #################### Constant ####################
 
 
@@ -362,7 +364,7 @@ def check_http_version(
         return return_err_msg_response(
             error,
             status_code=status.HTTP_505_HTTP_VERSION_NOT_SUPPORTED,
-            logger=logging.info,
+            logger=logger.info,
         )
 
 

--- a/src/fastapi_proxy_lib/core/http.py
+++ b/src/fastapi_proxy_lib/core/http.py
@@ -42,7 +42,7 @@ __all__ = (
     "ForwardHttpProxy",
 )
 
-logger = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 #################### Data Model ####################
 
@@ -275,7 +275,7 @@ class BaseHttpProxy(BaseProxyModel):
         )
 
         # DEBUG: 用于调试的记录
-        logger.debug(
+        _logger.debug(
             "HTTP: client:%s ; url:%s ; head:%s",
             request.client,
             proxy_request.url,
@@ -437,7 +437,7 @@ class ReverseHttpProxy(BaseHttpProxy):
                     "Oops! Something wrong! Please contact the server maintainer!"
                 ),
                 status_code=starlette_status.HTTP_502_BAD_GATEWAY,
-                logger=logger.exception,
+                logger=_logger.exception,
                 _msg=msg,
                 _exc_info=e,
             )
@@ -553,7 +553,7 @@ class ForwardHttpProxy(BaseHttpProxy):
             return return_err_msg_response(
                 e,
                 status_code=starlette_status.HTTP_400_BAD_REQUEST,
-                logger=logger.critical,
+                logger=_logger.critical,
             )
 
         # 进行请求过滤
@@ -578,7 +578,7 @@ class ForwardHttpProxy(BaseHttpProxy):
             return return_err_msg_response(
                 e,
                 status_code=starlette_status.HTTP_500_INTERNAL_SERVER_ERROR,
-                logger=logger.exception,
+                logger=_logger.exception,
                 _exc_info=e,
             )
         # 请注意，我们不返回其他错误给客户端，因为这可能涉及到服务器内部的信息泄露

--- a/src/fastapi_proxy_lib/core/http.py
+++ b/src/fastapi_proxy_lib/core/http.py
@@ -42,6 +42,8 @@ __all__ = (
     "ForwardHttpProxy",
 )
 
+logger = logging.getLogger(__name__)
+
 #################### Data Model ####################
 
 
@@ -273,7 +275,7 @@ class BaseHttpProxy(BaseProxyModel):
         )
 
         # DEBUG: 用于调试的记录
-        logging.debug(
+        logger.debug(
             "HTTP: client:%s ; url:%s ; head:%s",
             request.client,
             proxy_request.url,
@@ -435,7 +437,7 @@ class ReverseHttpProxy(BaseHttpProxy):
                     "Oops! Something wrong! Please contact the server maintainer!"
                 ),
                 status_code=starlette_status.HTTP_502_BAD_GATEWAY,
-                logger=logging.exception,
+                logger=logger.exception,
                 _msg=msg,
                 _exc_info=e,
             )
@@ -551,7 +553,7 @@ class ForwardHttpProxy(BaseHttpProxy):
             return return_err_msg_response(
                 e,
                 status_code=starlette_status.HTTP_400_BAD_REQUEST,
-                logger=logging.critical,
+                logger=logger.critical,
             )
 
         # 进行请求过滤
@@ -576,7 +578,7 @@ class ForwardHttpProxy(BaseHttpProxy):
             return return_err_msg_response(
                 e,
                 status_code=starlette_status.HTTP_500_INTERNAL_SERVER_ERROR,
-                logger=logging.exception,
+                logger=logger.exception,
                 _exc_info=e,
             )
         # 请注意，我们不返回其他错误给客户端，因为这可能涉及到服务器内部的信息泄露

--- a/src/fastapi_proxy_lib/core/websocket.py
+++ b/src/fastapi_proxy_lib/core/websocket.py
@@ -622,12 +622,12 @@ class BaseWebSocketProxy(BaseProxyModel):
                         await asyncio.wait_for(pending_task, timeout=1)
                     except asyncio.TimeoutError:
                         _logger.debug(f"{pending} TimeoutError, it's normal.")
-                    except Exception as e:
+                    except Exception as e:  # pragma: no cover # usually unreachable
                         # 取消期间可能另一个ws会发生异常，这个是正常情况，且会被 asyncio.wait_for 传播
                         _logger.debug(
                             f"{pending} raise error when being canceled, it's normal. error: {e}"
                         )
-            except Exception as e:  # pragma: no cover # 这个是保险分支，通常无法执行
+            except Exception as e:  # pragma: no cover # usually unreachable
                 _logger.warning(
                     f"Something wrong, please contact the developer. error: {e}"
                 )

--- a/src/fastapi_proxy_lib/core/websocket.py
+++ b/src/fastapi_proxy_lib/core/websocket.py
@@ -48,7 +48,7 @@ if TYPE_CHECKING:
     # 这些是私有模块，无法确定以后版本是否会改变，为了保证运行时不会出错，我们使用TYPE_CHECKING
     from httpx._types import HeaderTypes, QueryParamTypes
 
-logger = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 #################### Data Model ####################
 
@@ -198,7 +198,7 @@ async def _httpx_ws_receive_bytes_or_str(
             return bytes(event.data)
     else:  # pragma: no cover # 无法测试这个分支，因为无法发送这种消息，正常来说也不会被执行，所以我们这里记录critical
         msg = f"Invalid message type received: {type(event)}"
-        logger.critical(msg)
+        _logger.critical(msg)
         raise httpx_ws.WebSocketInvalidTypeReceived(event)
 
 
@@ -367,12 +367,12 @@ An error occurred in the websocket connection for {client_host}:{client_port}.
 client_error: {client_error}
 server_error: {server_error}\
 """
-            logger.warning(msg)
+            _logger.warning(msg)
 
     except (
         Exception
     ) as e:  # pragma: no cover # 这个分支是一个保险分支，通常无法执行，所以只进行记录
-        logger.error(
+        _logger.error(
             f"{e} when close ws connection. client: {client_to_server_task}, server:{server_to_client_task}"
         )
         raise
@@ -391,7 +391,7 @@ server_error: {server_error}\
         except Exception as e:  # pragma: no cover
             # 这个分支是一个保险分支，通常无法执行，所以只进行记录
             # 不会触发的原因是，负责服务端 ws 连接的 httpx_ws 支持重复调用close而不引发错误
-            logger.debug("Unexpected error for debug", exc_info=e)
+            _logger.debug("Unexpected error for debug", exc_info=e)
 
 
 #################### # ####################
@@ -504,7 +504,7 @@ class BaseWebSocketProxy(BaseProxyModel):
             return check_result
 
         # DEBUG: 用于调试的记录
-        logger.debug(
+        _logger.debug(
             "WS: client:%s ; url:%s ; params:%s ; headers:%s",
             websocket.client,
             target_url,
@@ -622,14 +622,14 @@ class BaseWebSocketProxy(BaseProxyModel):
                     try:
                         await asyncio.wait_for(pending_task, timeout=1)
                     except asyncio.TimeoutError:
-                        logger.debug(f"{pending} TimeoutError, it's normal.")
+                        _logger.debug(f"{pending} TimeoutError, it's normal.")
                     except Exception as e:
                         # 取消期间可能另一个ws会发生异常，这个是正常情况，且会被 asyncio.wait_for 传播
-                        logger.debug(
+                        _logger.debug(
                             f"{pending} raise error when being canceled, it's normal. error: {e}"
                         )
             except Exception as e:  # pragma: no cover # 这个是保险分支，通常无法执行
-                logger.warning(
+                _logger.warning(
                     f"Something wrong, please contact the developer. error: {e}"
                 )
                 raise

--- a/src/fastapi_proxy_lib/core/websocket.py
+++ b/src/fastapi_proxy_lib/core/websocket.py
@@ -48,6 +48,7 @@ if TYPE_CHECKING:
     # 这些是私有模块，无法确定以后版本是否会改变，为了保证运行时不会出错，我们使用TYPE_CHECKING
     from httpx._types import HeaderTypes, QueryParamTypes
 
+logger = logging.getLogger(__name__)
 
 #################### Data Model ####################
 
@@ -197,7 +198,7 @@ async def _httpx_ws_receive_bytes_or_str(
             return bytes(event.data)
     else:  # pragma: no cover # 无法测试这个分支，因为无法发送这种消息，正常来说也不会被执行，所以我们这里记录critical
         msg = f"Invalid message type received: {type(event)}"
-        logging.critical(msg)
+        logger.critical(msg)
         raise httpx_ws.WebSocketInvalidTypeReceived(event)
 
 
@@ -366,12 +367,12 @@ An error occurred in the websocket connection for {client_host}:{client_port}.
 client_error: {client_error}
 server_error: {server_error}\
 """
-            logging.warning(msg)
+            logger.warning(msg)
 
     except (
         Exception
     ) as e:  # pragma: no cover # 这个分支是一个保险分支，通常无法执行，所以只进行记录
-        logging.error(
+        logger.error(
             f"{e} when close ws connection. client: {client_to_server_task}, server:{server_to_client_task}"
         )
         raise
@@ -390,7 +391,7 @@ server_error: {server_error}\
         except Exception as e:  # pragma: no cover
             # 这个分支是一个保险分支，通常无法执行，所以只进行记录
             # 不会触发的原因是，负责服务端 ws 连接的 httpx_ws 支持重复调用close而不引发错误
-            logging.debug("Unexpected error for debug", exc_info=e)
+            logger.debug("Unexpected error for debug", exc_info=e)
 
 
 #################### # ####################
@@ -503,7 +504,7 @@ class BaseWebSocketProxy(BaseProxyModel):
             return check_result
 
         # DEBUG: 用于调试的记录
-        logging.debug(
+        logger.debug(
             "WS: client:%s ; url:%s ; params:%s ; headers:%s",
             websocket.client,
             target_url,
@@ -621,14 +622,14 @@ class BaseWebSocketProxy(BaseProxyModel):
                     try:
                         await asyncio.wait_for(pending_task, timeout=1)
                     except asyncio.TimeoutError:
-                        logging.debug(f"{pending} TimeoutError, it's normal.")
+                        logger.debug(f"{pending} TimeoutError, it's normal.")
                     except Exception as e:
                         # 取消期间可能另一个ws会发生异常，这个是正常情况，且会被 asyncio.wait_for 传播
-                        logging.debug(
+                        logger.debug(
                             f"{pending} raise error when being canceled, it's normal. error: {e}"
                         )
             except Exception as e:  # pragma: no cover # 这个是保险分支，通常无法执行
-                logging.warning(
+                logger.warning(
                     f"Something wrong, please contact the developer. error: {e}"
                 )
                 raise


### PR DESCRIPTION
Calling these methods might add handlers to the root logger, which can interfere with applications that don't use it.

Fix #45.

# Checklist

- [x] I've read `CONTRIBUTING.md`.
- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
