### PR TITLE
fix(security): add `localhost` rule to `default_proxy_filter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#49](https://github.com/WSH032/fastapi-proxy-lib/pull/49) - fix!: bump `httpx-ws >= 0.7.1` to fix frankie567/httpx-ws#29. Thanks [@WSH032](https://github.com/WSH032)!
 
+### Security
+
+- [#50](https://github.com/WSH032/fastapi-proxy-lib/pull/50) - fix(security): add `localhost` rule to `default_proxy_filter`. Thanks [@WSH032](https://github.com/WSH032)!
+
 ### Internal
 
 - [#47](https://github.com/WSH032/fastapi-proxy-lib/pull/47) - test: do not use deprecated and removed APIs of httpx. Thanks [@WSH032](https://github.com/WSH032)!

--- a/src/fastapi_proxy_lib/core/_tool.py
+++ b/src/fastapi_proxy_lib/core/_tool.py
@@ -368,7 +368,12 @@ def check_http_version(
 def default_proxy_filter(url: httpx.URL) -> Union[None, str]:
     """Filter by host.
 
-    If the host of url is ip address, which is not global ip address, then will reject it.
+    Reject the following hosts:
+
+    - if the host is ip address, and is not global ip address. e.g:
+        - `http://127.0.0.1`
+        - `http://192.168.0.1`
+    - if the host contains "localhost".
 
     Warning:
         It will consumption time: 3.22~4.7 µs ± 42.6 ns.
@@ -381,8 +386,12 @@ def default_proxy_filter(url: httpx.URL) -> Union[None, str]:
         str: should rejetc the proxy request.
             The `str` is the reason of reject.
     """
+    host = url.host
+    if "localhost" in host:
+        return "Deny proxy for localhost."
+
     try:
-        ip_address = ipaddress.ip_address(url.host)
+        ip_address = ipaddress.ip_address(host)
     except ValueError:
         return None
 
@@ -401,7 +410,7 @@ def warn_for_none_filter(proxy_filter: None) -> ProxyFilterProto: ...
 
 
 def warn_for_none_filter(
-    proxy_filter: Union[ProxyFilterProto, None]
+    proxy_filter: Union[ProxyFilterProto, None],
 ) -> ProxyFilterProto:
     """Check whether the argument `proxy_filter` is None.
 


### PR DESCRIPTION
<!-- Thanks for contributing 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

Now, the `default_proxy_filter` will reject `http://localhost`.

<!-- Write a small summary about what is happening here. -->

# Checklist

- [x] I've read `CONTRIBUTING.md`.
- [x] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
